### PR TITLE
Update README.md: using 'sudo make shared_lib install' to install the rocksdb lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 -- STATUS UPDATE: functional features done, performance test and turning ahead ---
 
 ##### Installation
-* Install rocksdb as usual after git clone (e.g., sudo make install at the top directory)
+* Install rocksdb as usual after git clone (e.g., sudo make shared_lib install at the top directory)
 * Install [rDSN](https://github.com/Microsoft/rDSN/wiki/Installation)
 * Run the following commands and it should work
 ```bash


### PR DESCRIPTION
Using 'sudo make install' will install a uncompleted shared lib,  which will cause the following error during linking rrdb.

```
/tmp/ccNymlEb.o: In function `main':
rocksdb_example.cc:(.text+0x20b): undefined reference to `rocksdb::ReadOptions::ReadOptions()'
collect2: error: ld returned 1 exit status
```
